### PR TITLE
OpenRefine Pack

### DIFF
--- a/demos/openrefine/ContainerConfig.yaml
+++ b/demos/openrefine/ContainerConfig.yaml
@@ -1,20 +1,14 @@
 module:
-  code: OpenRefine
-  presentation: 21J
-type: web-app
+  code: XYZ123
+  presentation: 99A
+type: jupyter-notebook
+packs:
+  - openrefine
+openrefine:
+  version: '3.4.1' 
 packages:
-  apt:
-   - wget
-   - openjdk-11-jdk
-scripts:
-  build:
-    - commands: |
-        wget --no-check-certificate https://github.com/OpenRefine/OpenRefine/releases/download/3.3/openrefine-linux-3.3.tar.gz
-        mkdir /var/openrefine
-        tar -xzf openrefine-linux-3.3.tar.gz --directory /var/openrefine
-        rm openrefine-linux-3.3.tar.gz
+  pip:
+    - jupyter-server-proxy
 web_apps:
-  - path: openrefine
-    cmdline: /var/openrefine/openrefine-3.3/refine -i 0.0.0.0 -p "{port}" -d /home/ou-user/OpenRefine-21J
-    timeout: 120
-    default: true
+  - path:          openrefine
+    cmdline:       /var/openrefine/refine -i 0.0.0.0 -p {port} -d $HOME/openrefine

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -14,4 +14,5 @@ The API documentation is primarily meant for developers.
     packs_mariadb
     packs_services
     packs_tutorial_server
+    packs_openrefine
     validator

--- a/docs/api/packs_openrefine.rst
+++ b/docs/api/packs_openrefine.rst
@@ -1,0 +1,5 @@
+:mod:`ou_container_builder.packs.openrefine`
+=========================================
+
+.. automodule:: ou_container_builder.packs.openrefine
+   :members:

--- a/docs/configuration/packs/openrefine.rst
+++ b/docs/configuration/packs/openrefine.rst
@@ -1,0 +1,37 @@
+OpenRefine
+==========
+
+To enable the OpenRefine pack, add it to the top-level ``packs`` key:
+
+.. sourcecode:: yaml
+
+    packs:
+      - openrefine          # Install OpenRefine server .
+
+This installs the OpenRefine application and the Java runtime environment required to run it.
+The OpenRefine application is installed into the directory ``/var/openrefine/``.
+An ``openrefine`` directory is also created in the ``$HOME`` directory to store project files.
+
+To configure the installation use the top-level ``openrefine`` key:
+
+.. sourcecode:: yaml
+
+    openrefine:
+      version:  # Version of OpenRefine, as a string; current stable release is: '3.4.1'
+
+* ``version``: The version of OpenRefine o use. The current stable version is ``3.4.1``.
+
+The OpenRefine server can be accessed using the Jupyter Server Proxy in a Jupyter server container.
+
+To configure the Jupyter server container to use a proxied Open Refine server, in the container config file
+ensure that the ``jupyter-server-proxy`` package is installed and define an OpenRefine web application:
+
+.. sourcecode::
+
+    packages:
+      pip:
+        - jupyter-server-proxy
+
+    web_apps:
+      - path:          openrefine
+        cmdline:       /var/openrefine/refine -i 0.0.0.0 -p {port} -d $HOME/openrefine

--- a/src/ou_container_builder/__main__.py
+++ b/src/ou_container_builder/__main__.py
@@ -56,7 +56,8 @@ def run_build(settings: dict, context: str, build: bool, clean: bool, tag: list)
                 settings = packs.tutorial_server(context, env, settings)
             if 'mariadb' in settings['packs']:
                 settings = packs.mariadb(context, env, settings)
-
+            if 'openrefine' in settings['packs']:
+                settings = packs.openrefine(context, env, settings)
         # Setup the generators
         if settings['type'] == 'jupyter-notebook':
             settings = generators.jupyter_notebook.setup(context, env, settings)

--- a/src/ou_container_builder/packs/__init__.py
+++ b/src/ou_container_builder/packs/__init__.py
@@ -7,6 +7,7 @@ which must be explicitly included in the ``ContainerConfig.yaml``.
 """
 from .tutorial_server import apply_pack as tutorial_server  # noqa
 from .mariadb import apply_pack as mariadb  # noqa
+from .openrefine import apply_pack as openrefine  # noqa
 from .services import apply_pack as services  # noqa
 from .content import apply_pack as content  # noqa
 from .scripts import apply_pack as scripts  # noqa

--- a/src/ou_container_builder/packs/openrefine.py
+++ b/src/ou_container_builder/packs/openrefine.py
@@ -1,0 +1,58 @@
+"""Pack to install the OpenRefine."""
+import os
+
+from jinja2 import Environment
+
+from ..utils import merge_settings
+
+
+def apply_pack(context: str, env: Environment, settings: dict) -> dict:
+    """Apply the openrefine pack.
+
+    This ensures that the openrefine application is installed and that the configured database is set up in the user's
+    home-directory.
+
+    The openrefine application is not started by default.
+    
+    We should perhaps provide a setting that does not start it by default, eg for use in Jupyter container where a proxy call will autostart it.
+
+    :param context: The context path within which the generation is running
+    :type context: str
+    :param env: The Jinja2 environment to use for loading and rendering templates
+    :type env: :class:`~jinja2.environment.Environment`
+    :param settings: The settings parsed from the configuration file
+    :type settings: dict
+    :return: The updated settings
+    :rtype: dict
+    """
+    # Latest stable OpenRefine version: '3.4.1' 
+    open_refine_version = settings["openrefine"]["version"]
+    settings = merge_settings(settings, {
+        'packages': {
+            'apt': ['wget', 'openjdk-11-jre'],
+        },
+        'scripts': {
+            'build': [
+                {
+                    'commands': [
+                        f"wget --no-check-certificate https://github.com/OpenRefine/OpenRefine/releases/download/{open_refine_version}/openrefine-linux-{open_refine_version}.tar.gz",
+                        f"tar -xzf openrefine-linux-{open_refine_version}.tar.gz",
+                        f"rm openrefine-linux-{open_refine_version}.tar.gz",
+                        f"mv openrefine-{open_refine_version} /var/openrefine",
+                        "mkdir -p $HOME/openrefine"
+                    ]
+                },
+            ],
+            'startup': [
+                {
+                    'commands': [
+                    ]
+                }
+            ]
+        },
+        'services': [
+        ],
+        'content': [
+        ]
+    })
+    return settings

--- a/src/ou_container_builder/packs/openrefine.py
+++ b/src/ou_container_builder/packs/openrefine.py
@@ -12,7 +12,7 @@ def apply_pack(context: str, env: Environment, settings: dict) -> dict:
 
     The openrefine application is not started by default.
 
-    We should perhaps provide a setting that does not start it by default, 
+    We should perhaps provide a setting that does not start it by default,
     eg for use in Jupyter container where a proxy call will autostart it.
 
     :param context: The context path within which the generation is running

--- a/src/ou_container_builder/packs/openrefine.py
+++ b/src/ou_container_builder/packs/openrefine.py
@@ -1,6 +1,4 @@
 """Pack to install the OpenRefine."""
-import os
-
 from jinja2 import Environment
 
 from ..utils import merge_settings
@@ -13,8 +11,9 @@ def apply_pack(context: str, env: Environment, settings: dict) -> dict:
     home-directory.
 
     The openrefine application is not started by default.
-    
-    We should perhaps provide a setting that does not start it by default, eg for use in Jupyter container where a proxy call will autostart it.
+
+    We should perhaps provide a setting that does not start it by default, 
+    eg for use in Jupyter container where a proxy call will autostart it.
 
     :param context: The context path within which the generation is running
     :type context: str
@@ -25,8 +24,9 @@ def apply_pack(context: str, env: Environment, settings: dict) -> dict:
     :return: The updated settings
     :rtype: dict
     """
-    # Latest stable OpenRefine version: '3.4.1' 
-    open_refine_version = settings["openrefine"]["version"]
+    # Latest stable OpenRefine version: '3.4.1'
+    openrefine_repo = "https://github.com/OpenRefine/OpenRefine/releases/download/"
+    version = settings["openrefine"]["version"]
     settings = merge_settings(settings, {
         'packages': {
             'apt': ['wget', 'openjdk-11-jre'],
@@ -35,10 +35,11 @@ def apply_pack(context: str, env: Environment, settings: dict) -> dict:
             'build': [
                 {
                     'commands': [
-                        f"wget --no-check-certificate https://github.com/OpenRefine/OpenRefine/releases/download/{open_refine_version}/openrefine-linux-{open_refine_version}.tar.gz",
-                        f"tar -xzf openrefine-linux-{open_refine_version}.tar.gz",
-                        f"rm openrefine-linux-{open_refine_version}.tar.gz",
-                        f"mv openrefine-{open_refine_version} /var/openrefine",
+                        f"wget --no-check-certificate \
+                            {openrefine_repo}{version}/openrefine-linux-{version}.tar.gz",
+                        f"tar -xzf openrefine-linux-{version}.tar.gz",
+                        f"rm openrefine-linux-{version}.tar.gz",
+                        f"mv openrefine-{version} /var/openrefine",
                         "mkdir -p $HOME/openrefine"
                     ]
                 },

--- a/src/ou_container_builder/validator.py
+++ b/src/ou_container_builder/validator.py
@@ -243,7 +243,7 @@ schema = {
         'type': 'list',
         'schema': {
             'type': 'string',
-            'allowed': ['tutorial-server', 'mariadb']
+            'allowed': ['tutorial-server', 'mariadb', 'openrefine']
         }
     },
     'tutorial_server': {
@@ -300,6 +300,16 @@ schema = {
                 'type': 'string',
                 'required': True,
                 'empty': False,
+            }
+        }
+    },
+    'openrefine': {
+        'type': 'dict',
+        'schema': {
+            'version': {
+                'type': 'string',
+                'required': True,
+                'empty': False
             }
         }
     },


### PR DESCRIPTION
I had a go at creating a pack to install OpenRefine to get a feel for what's involved.

There seems to be a lot of faffing about having to find and edit various various files to add the `openrefine` dependencies into. I had been hoping just to put everything into a single `packs` directory.

A handful of things I noticed in passing:

- the juptyer-server-proxy thing works well, although it would be useful to be able to add and icon for JuptyerLab;
- I couldn't seem to make `openrefine` parameters optional? It would be nice not to have to declare the `openrefine.version`, but instead to go with a default value baked into the pack source code.
- in defining the pack, in the startup commands, I couldn't create a directory in `$HOME`? The `$HOME` variable wasn't parsed but was treated as a literal string?
